### PR TITLE
fix: split factory deployment in 3 txs to overcome gas limits

### DIFF
--- a/contracts/Lootbox.sol
+++ b/contracts/Lootbox.sol
@@ -336,12 +336,14 @@ contract Lootbox is VRFV2WrapperConsumerBase, ERC721Holder, ERC1155Holder, ERC11
   /// @param _link The ChainLink LINK token address.
   /// @param _vrfV2Wrapper The ChainLink VRFV2Wrapper contract address.
   /// @param _view The LootboxView contract address.
+  /// @param _factory The LootboxFactory contract address.
   constructor(
     address _link,
     address _vrfV2Wrapper,
-    address _view
+    address _view,
+    address payable _factory
   ) VRFV2WrapperConsumerBase(_link, _vrfV2Wrapper) ERC1155PresetMinterPauser('') {
-    FACTORY = ILootboxFactory(payable(msg.sender));
+    FACTORY = ILootboxFactory(_factory);
     VIEW = _view;
   }
 

--- a/contracts/LootboxFactory.sol
+++ b/contracts/LootboxFactory.sol
@@ -45,9 +45,7 @@ contract LootboxFactory is ILootboxFactory, ERC677ReceiverInterface, Ownable {
   //////////////////////////////////////////////////////////////*/
 
   address public immutable LINK;
-  address public immutable VRFV2WRAPPER;
   address public immutable LOOTBOX;
-  address public immutable VIEW;
 
   uint public feePerDeploy = 0;
   mapping(address lootbox => uint feePerUnit) private fees;
@@ -69,21 +67,15 @@ contract LootboxFactory is ILootboxFactory, ERC677ReceiverInterface, Ownable {
   error AlreadyDeployed();
 
   /*//////////////////////////////////////////////////////////////
-                             VRF RELATED
-  //////////////////////////////////////////////////////////////*/
-
-  /*//////////////////////////////////////////////////////////////
                              CONSTRUCTOR
   //////////////////////////////////////////////////////////////*/
 
   constructor(
     address _link,
-    address _vrfV2Wrapper
+    address _lootbox
   ) {
     LINK = _link;
-    VRFV2WRAPPER = _vrfV2Wrapper;
-    VIEW = address(new LootboxView(_link, VRFV2WRAPPER));
-    LOOTBOX = address(new Lootbox(_link, _vrfV2Wrapper, VIEW));
+    LOOTBOX = _lootbox;
   }
 
   /*//////////////////////////////////////////////////////////////

--- a/contracts/LootboxView.sol
+++ b/contracts/LootboxView.sol
@@ -122,11 +122,13 @@ contract LootboxView is ERC721Holder, ERC1155Holder, ERC1155PresetMinterPauser {
   /// @notice Deploys a new Lootbox contract with the given parameters.
   /// @param _link The ChainLink LINK token address.
   /// @param _vrfV2Wrapper The ChainLink VRFV2Wrapper contract address.
+  /// @param _factory The LootboxFactory contract address.
   constructor(
     address _link,
-    address _vrfV2Wrapper
+    address _vrfV2Wrapper,
+    address payable _factory
   ) ERC1155PresetMinterPauser('') {
-    FACTORY = ILootboxFactory(payable(msg.sender));
+    FACTORY = ILootboxFactory(_factory);
     LINK_ETH_FEED = IVRFV2Wrapper(_vrfV2Wrapper).LINK_ETH_FEED();
     VRF_V2_WRAPPER = VRFV2WrapperInterface(_vrfV2Wrapper);
     LINK = _link;

--- a/test/Lootbox.js
+++ b/test/Lootbox.js
@@ -39,7 +39,12 @@ describe('Lootbox', function () {
     const wrapper = wrapperAddress || vrfV2Wrapper;
     const [owner, supplier, user] = await ethers.getSigners();
     const link = await ethers.getContractAt('LinkTokenInterface', linkAddress || linkToken);
-    const factory = await deploy('LootboxFactory', owner, link.address, wrapper);
+    const nonce = await ethers.provider.getTransactionCount(owner.address);
+    const lootboxAddress = ethers.utils.getContractAddress({from: owner.address, nonce: nonce + 1});
+    const viewAddress = ethers.utils.getContractAddress({from: owner.address, nonce: nonce + 2});
+    const factory = await deploy('LootboxFactory', owner, link.address, lootboxAddress, {nonce});
+    await deploy('Lootbox', owner, link.address, wrapper, viewAddress, factory.address, {nonce: nonce + 1});
+    await deploy('LootboxView', owner, link.address, wrapper, factory.address, {nonce: nonce + 2});
 
     const impersonatedLinkHolder = await ethers.getImpersonatedSigner(linkHolder);
     await link.connect(impersonatedLinkHolder)


### PR DESCRIPTION
Fantom network has a block gas limit set to less than 10.5M, but factory deployment (which internally deploys other contracts) took 10.5M. Now the deployment is split into 3 transactions, so the limit is not a problem anymore.